### PR TITLE
feat: adaptive GUI with improved disabled visibility

### DIFF
--- a/addons/arsenal/config.cpp
+++ b/addons/arsenal/config.cpp
@@ -85,20 +85,10 @@ class ace_arsenal_display {
                     w = QUOTE(80 * GRID_W);
                     h = QUOTE(4 * GRID_H);
                 };
-
-
-
-
             };
-
         };
-
-
 	};
-	
-
 };
-
 
 class GVAR(configTitle): RscText {
     sizeEx = QUOTE(5 * GRID_H);
@@ -109,6 +99,7 @@ class GVAR(configTitle): RscText {
     w = QUOTE(80 * GRID_W);
     h = QUOTE(5 * GRID_H);
 };
+
 class GVAR(valueImage): RscPicture {
     text = "";
     x = QUOTE(0 * GRID_W);
@@ -119,7 +110,8 @@ class GVAR(valueImage): RscPicture {
     style = 144;
     tileH = 0.5128;
     tileW = 1;
-}; 
+};
+
 class GVAR(valueImageCenterSquare): RscPictureKeepAspect {
     text = "";
     x = QUOTE(0 * GRID_W);
@@ -127,7 +119,8 @@ class GVAR(valueImageCenterSquare): RscPictureKeepAspect {
     w = QUOTE(19.5 * GRID_W);
     h = QUOTE(10 * GRID_H);
     colorBackground[] = {0,0,0,1};
-}; 
+};
+
 class GVAR(valueCheckbox): RscCheckBox {
     x = QUOTE(0 * GRID_W);
     y = QUOTE(0 * GRID_H);
@@ -143,7 +136,10 @@ class GVAR(valueCheckbox): RscCheckBox {
 	texturePressedUnchecked = QPATHTOF(data\ui\unchecked.paa);
 	textureDisabledChecked = QPATHTOF(data\ui\disabled.paa);
 	textureDisabledUnchecked = QPATHTOF(data\ui\disabled.paa);
+	colorDisabled[] = {0.1, 0.1, 0.1, 0.5};
+    colorBackgroundDisabled[] = {0.6, 0.6, 0.6, 0.25};
 };
+
 class GVAR(valueButton): RscButton {
     text = "Label";
     sizeEx = QUOTE(5 * GRID_H);
@@ -152,7 +148,7 @@ class GVAR(valueButton): RscButton {
     w = QUOTE(19.5 * GRID_W);
     h = QUOTE(10 * GRID_H);
 
-    colorText[] = {255,255,255,1};
+    colorText[] = {255, 255, 255, 1};
     colorBackground[] = {0, 0, 0, 0};
     colorFocused[] = {0, 0, 0, 0};
     colorShadow[] = {0, 0, 0, 0};

--- a/addons/arsenal/functions/fnc_generateOptionsUI.sqf
+++ b/addons/arsenal/functions/fnc_generateOptionsUI.sqf
@@ -12,13 +12,6 @@ GVAR(valuesIdc) = [];
 
 if ( _selectedModel != "" ) then {
 
-	_listControl ctrlSetPositionH (safezoneH - 128.5 * GRID_H);
-	_configControl ctrlSetPositionY ((safezoneY + 14 * GRID_H) + (safezoneH - 124.5 * GRID_H));
-	_configControl ctrlSetPositionH (100 * GRID_H);
-	_configControl ctrlShow true; // ensures visible
-	_listControl ctrlCommit 0.1;
-	_configControl ctrlCommit 0.1;
-	
 	private _modelDefinition = configFile >> "XtdGearModels" >> _classRoot >> _selectedModel;
 
 
@@ -99,23 +92,19 @@ if ( _selectedModel != "" ) then {
 
 	} forEach ["options","textureoptions"];
 
+	private _adjustedHeight = 120 min (_posY + 10);
+
+	_listControl ctrlSetPositionH (safezoneH - (_adjustedHeight + 28.5) * GRID_H);
+    _configControl ctrlSetPositionY ((safezoneY + 14 * GRID_H) + (safezoneH - (_adjustedHeight + 24.5) * GRID_H));
+    _configControl ctrlSetPositionH (_adjustedHeight * GRID_H);
+    _configControl ctrlShow true; // ensures visibility
+    _listControl ctrlCommit 0.2;
+    _configControl ctrlCommit 0.2;
+
 } else {
 	_listControl ctrlSetPositionH (safezoneH - 24.5 * GRID_H);
 	_configControl ctrlSetPositionY ((safezoneY + 14 * GRID_H) + (safezoneH - 24.5 * GRID_H));
 	_configControl ctrlSetPositionH (0);
-	_listControl ctrlCommit 0.1;
-	_configControl ctrlCommit 0.1;
+	_listControl ctrlCommit 0.2;
+	_configControl ctrlCommit 0.2;
 };
-
-// workaround scrollbar issue
-[{
-	params ["_listControl", "_configControl"];
-	if ( GVAR(currentModel) != "" ) then {
-		_listControl ctrlSetPositionH (safezoneH - 128.5 * GRID_H);
-		_configControl ctrlSetPositionY ((safezoneY + 14 * GRID_H) + (safezoneH - 124.5 * GRID_H));
-		_configControl ctrlSetPositionH (100 * GRID_H);
-		_listControl ctrlCommit 0;
-		_configControl ctrlCommit 0;
-	};
-}, [_listControl,_configControl], 1] call CBA_fnc_waitAndExecute;
-


### PR DESCRIPTION
This updates the GUI after adding the controls to the control group, which should resolve the scrollbar issues and make the workaround redundant. The height is adjusted to the content height of the included control group elements. The disabled texture was barely visible on top of background textures, so I've improved the contrast.