### PR TITLE
feat: make values selectable based on weak config match

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ class XtdGearModels
                 label = "Option A label";
                 values[] = {"value1", "value2"};
                 changeingame = 0; // 1 if value can be changed in game via ACE menu
+                alwaysSelectable = 1; // allows the selection of the values even if there isn't an item with a complete match of options available, falling back to a weak match with this single value (optional)
                 // changedelay = 2; If can changeingame, wait delay before change is effective (can be 0, 0.1, or more)
                 // icon = "xxx"; If can changeingame, action group icon in ACE menu
                 class value1

--- a/addons/arsenal/config.cpp
+++ b/addons/arsenal/config.cpp
@@ -148,12 +148,12 @@ class GVAR(valueButton): RscButton {
     w = QUOTE(19.5 * GRID_W);
     h = QUOTE(10 * GRID_H);
 
-    colorText[] = {255, 255, 255, 1};
-    colorBackground[] = {0, 0, 0, 0};
-    colorFocused[] = {0, 0, 0, 0};
-    colorShadow[] = {0, 0, 0, 0};
-    colorBorder[] = {0, 0, 0, 0};
-    colorBackgroundActive[] = {0, 0, 0, 0};
-    colorDisabled[] = {0, 0, 0, 0};
-    colorBackgroundDisabled[] = {0, 0, 0, 0};
+    colorText[] = {EXACT_MATCH_TEXT_COLOR};
+    colorBackground[] = {INVISIBLE_COLOR};
+    colorFocused[] = {INVISIBLE_COLOR};
+    colorShadow[] = {INVISIBLE_COLOR};
+    colorBorder[] = {INVISIBLE_COLOR};
+    colorBackgroundActive[] = {ACTIVE_BG_COLOR};
+    colorDisabled[] = {DISABLED_TEXT_COLOR};
+    colorBackgroundDisabled[] = {INVISIBLE_COLOR};
 };

--- a/addons/arsenal/functions/fnc_generateOptionsUI.sqf
+++ b/addons/arsenal/functions/fnc_generateOptionsUI.sqf
@@ -32,7 +32,7 @@ if ( _selectedModel != "" ) then {
 
 			private _optionIndex = _foreachIndex;
 
-			_x params  ["_optionName", "_optionLabel", "", "", "_values", "_optionCenterImage"];
+			_x params  ["_optionName", "_optionLabel", "", "", "_values", "", "_optionCenterImage"];
 
 			private _configIdcBase = _idcShift + 9980000 + _optionIndex;
 

--- a/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
+++ b/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
@@ -18,9 +18,8 @@ if ( _index == -1 ) exitWith {
 };
 
 private _selectedConfig = ace_arsenal_currentItems select _index;
-private _selectedModel = "";
-if ( _selectedConfig != "" ) then {
-	_selectedModel = [_classRoot, _selectedConfig] call EFUNC(gearinfo,getConfigModel);
+private _selectedModel = if (_selectedConfig == "") then { "" } else {
+	[_classRoot, _selectedConfig] call EFUNC(gearinfo,getConfigModel)
 };
 
 if ( _selectedModel != GVAR(currentModel) ) then {
@@ -29,9 +28,9 @@ if ( _selectedModel != GVAR(currentModel) ) then {
 	GVAR(currentConfig) = _classRoot;
 };
 
-if ( _selectedModel != "" ) then {
-	GVAR(currentModelOptions) = [_classRoot, _selectedConfig, _selectedModel] call EFUNC(gearinfo,getConfigOptions);
-	[_display] call FUNC(refreshCheckboxes);
+if (_selectedModel == "") exitWith {};
 
-	[ace_arsenal_center] call EFUNC(gearinfo,applyTextureOptions); 
-};
+GVAR(currentModelOptions) = [_classRoot, _selectedConfig, _selectedModel] call EFUNC(gearinfo,getConfigOptions);
+[_display] call FUNC(refreshCheckboxes);
+
+[ace_arsenal_center] call EFUNC(gearinfo,applyTextureOptions);

--- a/addons/arsenal/functions/fnc_refreshCheckboxes.sqf
+++ b/addons/arsenal/functions/fnc_refreshCheckboxes.sqf
@@ -5,55 +5,76 @@ params ["_display"];
 private _model = GVAR(currentModel);
 private _config = GVAR(currentConfig);
 
-if ( _model != "" ) then {
-	private _modelDefition = configFile >> "XtdGearModels" >> _config >> _model;
-	private _options = getArray ( _modelDefition >> "options" );
-	{
-		private _optionName = _x;
-		private _optionIndex = _foreachIndex;
-		private _currentValue = GVAR(currentModelOptions) select _optionIndex;
-		private _optionValues = getArray (_modelDefition >> _optionName >> "values");
+if ( _model == "" ) exitWith {};
 
-		{
-			private _valueName = _x;
-			private _valueIndex = _foreachIndex;
-			private _valueIdcBase = 9900000 + (_optionIndex * 1000) + (_valueIndex * 4);
-			
-			private _previewOptions = +GVAR(currentModelOptions);
-			_previewOptions set [_optionIndex, _valueName];
+private _modelDefition = configFile >> "XtdGearModels" >> _config >> _model;
+private _options = [_config, _model, _modelDefinition, "options"] call EFUNC(gearinfo,getModelOptions);
+{
+    private _optionIndex = _foreachIndex;
+    _x params  ["_optionName", "", "", "", "_values", "_alwaysSelectable"];
+    private _currentValue = GVAR(currentModelOptions) select _optionIndex;
 
-			private _ctrl = _display displayCtrl (_valueIdcBase + 1);
-			_ctrl cbSetChecked (_valueName == _currentValue);
-			_ctrl ctrlEnable !isNull ([GVAR(currentConfig), GVAR(currentModel), _previewOptions] call EFUNC(gearinfo,findConfig));
-			_ctrl ctrlCommit 0;
-		} forEach _optionValues;
+    {
+        private _valueIndex = _foreachIndex;
+        _x params ["_valueName"];
 
-	} forEach _options;
+        private _valueIdcBase = 9900000 + (_optionIndex * 1000) + (_valueIndex * 4);
 
+        private _previewOptions = +GVAR(currentModelOptions);
+        private _optionSet = [_optionIndex, _valueName];
+        _previewOptions set _optionSet;
 
-	private _textureoptions = [_config, _model, _modelDefinition, "textureoptions"] call EFUNC(gearinfo,getModelOptions);
-	{
-		private _optionIndex = _foreachIndex;
-		_x params  ["_optionName", "", "", "", "_values", "", "_requires"];
-		private _currentValue = [ace_arsenal_center, GVAR(currentModel), _optionName] call EFUNC(gearinfo,getTextureOption);
-		private _enabled = true;
+        private _ctrl = _display displayCtrl (_valueIdcBase + 1);
+        private _button = _display displayCtrl (_valueIdcBase + 2);
 
-		{
-			_x params ["_reqIdx","_reqValue"];
-			_enabled = _enabled && ((GVAR(currentModelOptions) select _reqIdx) == _reqValue);
-		} forEach _requires;
+        private _exactMatch = not isNull ([_config, _model, _previewOptions] call EFUNC(gearinfo,findConfig));
 
-		private _posX = 0;
-		{
-			private _valueIndex = _foreachIndex;
-			_x params ["_valueName"];
-			private _valueIdcBase = 9940000 + (_optionIndex * 1000) + (_valueIndex * 4);
-			private _ctrl = _display displayCtrl (_valueIdcBase + 1);
-			_ctrl cbSetChecked (_valueName == _currentValue);
-			_ctrl ctrlEnable _enabled;
-			_ctrl ctrlCommit 0;
-		} forEach _values;
-	} forEach _textureoptions;
-	
+        // If always selectable is enabled, only grey out the button as long as there is a weak config match (i.e. a superset of perfect) available
+        private _enabled = if (not _alwaysSelectable) then { _exactMatch } else {
+            if (_exactMatch) then { true } else {
+                not isNull ([_config, _model, _optionSet] call EFUNC(gearinfo,findConfigByValue))
+            }
+        };
 
-};
+        if (_alwaysSelectable) then {
+            private _bgColor = [[WEAK_MATCH_BG_COLOR], [INVISIBLE_COLOR]] select _exactMatch;
+            _button ctrlSetBackgroundColor _bgColor;
+        };
+
+        private _textColor = [[WEAK_MATCH_TEXT_COLOR], [EXACT_MATCH_TEXT_COLOR]] select _exactMatch;
+        _button ctrlSetTextColor _textColor;
+        _button ctrlEnable _enabled;
+        _button ctrlCommit 0.1;
+
+        _ctrl cbSetChecked (_valueName == _currentValue);
+        _ctrl ctrlEnable _enabled;
+        _ctrl ctrlCommit 0;
+
+    } forEach _values;
+
+} forEach _options;
+
+private _textureoptions = [_config, _model, _modelDefinition, "textureoptions"] call EFUNC(gearinfo,getModelOptions);
+{
+    private _optionIndex = _foreachIndex;
+    _x params  ["_optionName", "", "", "", "_values", "", "", "_requires"];
+    private _currentValue = [ace_arsenal_center, _model, _optionName] call EFUNC(gearinfo,getTextureOption);
+    private _enabled = true;
+
+    {
+        _x params ["_reqIdx","_reqValue"];
+        _enabled = _enabled && ((GVAR(currentModelOptions) select _reqIdx) == _reqValue);
+    } forEach _requires;
+
+    private _posX = 0;
+    {
+        private _valueIndex = _foreachIndex;
+        _x params ["_valueName"];
+        private _valueIdcBase = 9940000 + (_optionIndex * 1000) + (_valueIndex * 4);
+        private _ctrl = _display displayCtrl (_valueIdcBase + 1);
+        _ctrl cbSetChecked (_valueName == _currentValue);
+        _ctrl ctrlEnable _enabled;
+        _ctrl ctrlCommit 0;
+    } forEach _values;
+
+} forEach _textureoptions;

--- a/addons/arsenal/script_component.hpp
+++ b/addons/arsenal/script_component.hpp
@@ -12,3 +12,12 @@
 #endif
 
 #include "\z\aceax\addons\main\script_macros.hpp"
+
+#define INVISIBLE_COLOR 0, 0, 0, 0
+
+#define WEAK_MATCH_BG_COLOR 0.4, 0.4, 0.4, 0.4
+#define ACTIVE_BG_COLOR 0.5, 0.5, 0.5, 0.2
+
+#define EXACT_MATCH_TEXT_COLOR 1, 1, 1, 1
+#define WEAK_MATCH_TEXT_COLOR 0.9, 0.9, 0.9, 0.9
+#define DISABLED_TEXT_COLOR 0.8, 0.8, 0.8, 0.8

--- a/addons/gearinfo/XEH_PREP.hpp
+++ b/addons/gearinfo/XEH_PREP.hpp
@@ -1,4 +1,6 @@
+PREP(variations);
 PREP(findConfig);
+PREP(findConfigByValue);
 PREP(findConfigName);
 PREP(getConfigOptions);
 PREP(getConfigModel);

--- a/addons/gearinfo/XEH_preInit.sqf
+++ b/addons/gearinfo/XEH_preInit.sqf
@@ -4,6 +4,7 @@ ADDON = false;
 ADDON = true;
 
 GVAR(cache) = createHashMap;
+GVAR(weakMatchesCache) = createHashMap;
 
 #ifdef DEBUG_MODE_FULL
 [""] call FUNC(diag_detectErrors);

--- a/addons/gearinfo/XtdGearModels.hpp
+++ b/addons/gearinfo/XtdGearModels.hpp
@@ -171,6 +171,7 @@ class XtdGearModels
     {
         label = CSTRING(Faction);
         values[] = {};
+        alwaysSelectable = 1;
         FACTION_OPTION(NATO,NATO_CTRG_COMBINED);
         FACTION_OPTION(CTRG,CTRG_FACTION);
         FACTION_OPTION(USA,NATO_FACTION);

--- a/addons/gearinfo/functions/fnc_findConfig.sqf
+++ b/addons/gearinfo/functions/fnc_findConfig.sqf
@@ -2,17 +2,6 @@
 
 params ["_classRoot", "_model", "_options"];
 
-private _variations = GVAR(cache) getOrDefault [_model, []];
+private _variations = [_classRoot, _model] call FUNC(variations);
 
-if ( count _variations == 0 ) then {
-
-	_variations = createHashMap;
-	{
-		_x params ["_config","_configOptions"],
-		_variations set [_configOptions, _config];
-	} foreach ([_classRoot, _model] call FUNC(getModelConfigs));
-
-	GVAR(cache) set [_model, _variations];
-};
-
-_variations getOrDefault [_options, configNull]
+_variations getOrDefault [_options, configNull, true]

--- a/addons/gearinfo/functions/fnc_findConfigByValue.sqf
+++ b/addons/gearinfo/functions/fnc_findConfigByValue.sqf
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+
+params ["_classRoot", "_model", "_optionSet"];
+_optionSet params ["_optionIndex", "_valueName"];
+
+private _firstMatch = GVAR(weakMatchesCache) getOrDefault [[_classRoot, _model, _optionSet], configNull];
+
+if (not isNull _firstMatch) exitWith {
+    _firstMatch
+};
+
+private _variations = [_classRoot, _model] call FUNC(variations);
+
+{
+    private _selectedOption = _x select _optionIndex;
+    private _varConfig = _y;
+
+    if (not isNull _varConfig and _selectedOption == _valueName) exitWith {
+        GVAR(weakMatchesCache) set [[_classRoot, _model, _optionSet], _varConfig];
+        _firstMatch = _varConfig
+    };
+} forEach _variations;
+
+_firstMatch

--- a/addons/gearinfo/functions/fnc_getConfigModel.sqf
+++ b/addons/gearinfo/functions/fnc_getConfigModel.sqf
@@ -2,7 +2,7 @@
 
 params ["_classRoot", "_config"];
 
-private _model = configFile>> "XtdGearInfos" >> _classRoot >> _config >> "model";
+private _model = configFile >> "XtdGearInfos" >> _classRoot >> _config >> "model";
 if ( isText _model ) exitWith { getText _model };
 
-[configFile >> _classRoot >> _config >> "XtdGearInfo", "model", ""] call BIS_fnc_returnConfigEntry;
+[configFile >> _classRoot >> _config >> "XtdGearInfo", "model", ""] call BIS_fnc_returnConfigEntry

--- a/addons/gearinfo/functions/fnc_getModelOptions.sqf
+++ b/addons/gearinfo/functions/fnc_getModelOptions.sqf
@@ -24,6 +24,7 @@ private _options = [];
 	private _optionIcon = [_optionDef1, _optionDef2, "icon", ""] call READ_TEXT;
 	private _optionInGame = [_optionDef1, _optionDef2, "changeingame", 0] call READ_NUMBER;
 	private _optionDelay = [_optionDef1, _optionDef2, "changedelay", 2] call READ_NUMBER;
+	private _alwaysSelectable = 1 == ([_optionDef1, _optionDef2, "alwaysSelectable", 0] call READ_NUMBER);
 	private _values = [];
 	private _optionCenterImage = getNumber (_optionDef1 >> "centerImage");
 	private _optionValues = getArray (_optionDef1 >> "values");
@@ -53,7 +54,7 @@ private _options = [];
 
 	} forEach _optionValues;
 
-	_options pushBack [_optionName, _optionLabel, _optionIcon, _optionInGame, _values, _optionCenterImage, _requires];
+	_options pushBack [_optionName, _optionLabel, _optionIcon, _optionInGame, _values, _alwaysSelectable, _optionCenterImage, _requires];
 	
 } forEach _optionsNames;
 

--- a/addons/gearinfo/functions/fnc_variations.sqf
+++ b/addons/gearinfo/functions/fnc_variations.sqf
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+params ["_classRoot", "_model"];
+
+private _variations = GVAR(cache) getOrDefault [_model, []];
+
+if (count _variations == 0) then {
+
+	_variations = createHashMap;
+	{
+		_x params ["_config","_configOptions"],
+		_variations set [_configOptions, _config];
+	} foreach ([_classRoot, _model] call FUNC(getModelConfigs));
+
+	GVAR(cache) set [_model, _variations];
+};
+
+_variations


### PR DESCRIPTION
The current logic disables buttons by determining if there is any exact config match with the currently selected button set. This isn't an issue when the set of configs is mostly complete, so all configurations are easily accessible. It's more difficult, however, to select find configs with specific values when the set is incomplete and buttons remain disabled most of the time.

This feature introduces an optional attribute that enables a weak config matching for a specific option. It distinguishes exact matches from weak matches where only this specific value is relevant and not the complete set of options. When there isn't any weak match available, the button remains disabled. Weak matches will be greyed out without a texture and remain selectable. Disabled buttons are disabled now and won't trigger a function call. A click on a greyed-out button will select the first-best match with the specified value, disregarding any other options.

For instance, when there is only one config available with a specific camo and you don't want the user to click all possible button combinations, when enabling the `alwaysSelectable = 1` option for camo, it looks like this:

![always-selectable-before](https://user-images.githubusercontent.com/15669918/170017161-de06c44a-8908-4b00-bd83-27fe7c278e5a.png)

In this example, all the greyed-out camos don't have an officer variant available, so they would normally be disabled. But now, with `alwaysSelectable` enabled, a selection of the `CTRG` camo will find a weak match. This happens to be the rolled-up variant. Also notice that the Navy camo is disabled because I haven't added any config that references a Navy camo. It is just listed in the `values` for testing purposes. Here is how the screen looks after clicking on `CTRG`:

![always-selectable-after](https://user-images.githubusercontent.com/15669918/170017551-7a397c10-f45c-4d9c-ac9b-c94942c6421f.png)

I also reduced the nested statements in the files with already significant logical changes to make the code more readable and maintainable.