### PR TITLE
fix: invalid else if syntax in setUnitLoadout

### DIFF
--- a/addons/gearinfo/functions/fnc_setUnitLoadout.sqf
+++ b/addons/gearinfo/functions/fnc_setUnitLoadout.sqf
@@ -5,7 +5,9 @@ params ["_unit", "_data", ["_useInsignia", true]];
 if (count _data == 10) then {
 	_unit setUnitLoadout _data;
 
-} else if (count _data == 11) then {
-	_unit setUnitLoadout (_data select [0, 10]);
-	[_unit, _data select 10, _useInsignia] call FUNC(setTextureOptions);
+} else {
+    if (count _data == 11) then {
+        _unit setUnitLoadout (_data select [0, 10]);
+        [_unit, _data select 10, _useInsignia] call FUNC(setTextureOptions);
+	};
 };


### PR DESCRIPTION
`else if`s don't exist in A3 afaik. `else if` doesn't work in my debugging console.