### PR TITLE
perf: optimized cache miss handling of weak config matches

### DIFF
--- a/addons/arsenal/functions/fnc_changeCurrentConfig.sqf
+++ b/addons/arsenal/functions/fnc_changeCurrentConfig.sqf
@@ -12,13 +12,12 @@ if ( _type == "textureoptions" ) exitWith {
 if ((GVAR(currentModelOptions) select _optionIndex) == _valueName) exitWith {};
 
 private _options = +GVAR(currentModelOptions);
-private _optionSet = [_optionIndex, _valueName];
-_options set _optionSet;
+_options set [_optionIndex, _valueName];
 
 private _match = [GVAR(currentConfig), GVAR(currentModel), _options] call EFUNC(gearinfo,findConfig);
 
 if (isNull _match) then {
-    _match = [GVAR(currentConfig), GVAR(currentModel), _optionSet] call EFUNC(gearinfo,findConfigByValue);
+    _match = [GVAR(currentConfig), GVAR(currentModel), _optionIndex, _valueName] call EFUNC(gearinfo,findConfigByValue);
 };
 
 if (isNull _match) exitWith {

--- a/addons/arsenal/functions/fnc_refreshCheckboxes.sqf
+++ b/addons/arsenal/functions/fnc_refreshCheckboxes.sqf
@@ -21,8 +21,7 @@ private _options = [_config, _model, _modelDefinition, "options"] call EFUNC(gea
         private _valueIdcBase = 9900000 + (_optionIndex * 1000) + (_valueIndex * 4);
 
         private _previewOptions = +GVAR(currentModelOptions);
-        private _optionSet = [_optionIndex, _valueName];
-        _previewOptions set _optionSet;
+        _previewOptions set [_optionIndex, _valueName];
 
         private _ctrl = _display displayCtrl (_valueIdcBase + 1);
         private _button = _display displayCtrl (_valueIdcBase + 2);
@@ -32,7 +31,7 @@ private _options = [_config, _model, _modelDefinition, "options"] call EFUNC(gea
         // If always selectable is enabled, only grey out the button as long as there is a weak config match (i.e. a superset of perfect) available
         private _enabled = if (not _alwaysSelectable) then { _exactMatch } else {
             if (_exactMatch) then { true } else {
-                not isNull ([_config, _model, _optionSet] call EFUNC(gearinfo,findConfigByValue))
+                not isNull ([_config, _model, _optionIndex, _valueName] call EFUNC(gearinfo,findConfigByValue))
             }
         };
 

--- a/addons/gearinfo/functions/fnc_findConfigByValue.sqf
+++ b/addons/gearinfo/functions/fnc_findConfigByValue.sqf
@@ -1,24 +1,24 @@
 #include "script_component.hpp"
 
-params ["_classRoot", "_model", "_optionSet"];
-_optionSet params ["_optionIndex", "_valueName"];
+params ["_classRoot", "_model", "_optionIndex", "_valueName"];
 
-private _firstMatch = GVAR(weakMatchesCache) getOrDefault [[_classRoot, _model, _optionSet], configNull];
-
-if (not isNull _firstMatch) exitWith {
-    _firstMatch
-};
+private _cacheKey = [_classRoot, _model, _optionIndex, _valueName];
+private _getter = { GVAR(weakMatchesCache) get _cacheKey };
+if (not isNil _getter) exitWith _getter;
 
 private _variations = [_classRoot, _model] call FUNC(variations);
+
+private _firstMatch = configNull;
 
 {
     private _selectedOption = _x select _optionIndex;
     private _varConfig = _y;
 
     if (not isNull _varConfig and _selectedOption == _valueName) exitWith {
-        GVAR(weakMatchesCache) set [[_classRoot, _model, _optionSet], _varConfig];
-        _firstMatch = _varConfig
+        _firstMatch = _varConfig;
     };
 } forEach _variations;
+
+GVAR(weakMatchesCache) set [_cacheKey, _firstMatch];
 
 _firstMatch


### PR DESCRIPTION
This checks the cache for a hit instead of defaulting to a configNull in order to make `configNull` distinct from cache misses. This allows storage of `configNull` types as cached items, skipping the rechecking of the matches.