### PR TITLE
fix: add delay before applying textures

### DIFF
--- a/addons/gearinfo/XEH_postInit.sqf
+++ b/addons/gearinfo/XEH_postInit.sqf
@@ -4,7 +4,10 @@
     params ["_unit", "_loadout", "_extendedInfo"];
     private _textureOptions = _extendedInfo getOrDefault [QGVARMAIN(textureOptions), []];
     if (_textureOptions isNotEqualTo []) then {
-        [_unit, _textureOptions, false] call FUNC(setTextureOptions);
+        [_unit, _textureOptions, false] spawn {
+            sleep 1; // Let setUnitLoadout to propagate over network
+            [FUNC(setTextureOptions), _this] call CBA_fnc_directCall;
+        };
     };
 }] call CBA_fnc_addEventHandler;
 

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 0
 #define MINOR 8
-#define PATCH 0
+#define PATCH 1
 #define BUILD 0


### PR DESCRIPTION
This fixes an issue preventing textures from being applied when CBA_fnc_setLoadout is used.

This could fix #34.