### PR TITLE
Fix typo

### DIFF
--- a/compats/compat_rhs/XtdGearInfos/rhs_headgear/CfgWeapons/rhs_altyn.hpp
+++ b/compats/compat_rhs/XtdGearInfos/rhs_headgear/CfgWeapons/rhs_altyn.hpp
@@ -1,7 +1,7 @@
 class rhs_altyn_novisor {
   model = "rhs_altyn";
   visor = "None";
-  balaclava = "Yes";
+  balaclava = "No";
   goggles = "None";
 };
 


### PR DESCRIPTION
It was previously impossible to select the plain Altyn. `rhs_altyn_novisor` and `rhs_altyn_novisor_bala` had identical configurations.