### PR TITLE
Upgrade Hemtt Versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -354,7 +354,9 @@ releases/*
 keys/*
 .hemtt/local
 *.pbo
-/hemtt.exe
+hemtt/
+.hemttout/
+hemtt.exe
 
 # APL-ND assets / Will be available later in AMF
 /compats/compat_amf/data/*_gloves*

--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -5,6 +5,11 @@ template = "cba"
 mainprefix = "z"
 folder_optionals = true
 sig_version = 3
+
+[version]
+path = "addons/main/script_version.hpp"
+git_hash = 0
+
 files = [
     "mod.cpp",
     "logo.paa"

--- a/addons/arsenal/config.cpp
+++ b/addons/arsenal/config.cpp
@@ -27,7 +27,7 @@ class RscEdit;
 
 class ace_arsenal_display {
 
-	onUnload = QUOTE([ARR_3('onUnload', _this, QUOTE(QUOTE(ace_arsenal_display)))] call FUNC(onArsenalClose));
+	onUnload = QUOTE([ARR_3('onUnload',_this,QUOTE(QUOTE(ace_arsenal_display)))] call FUNC(onArsenalClose));
 
 	class controls {
 
@@ -64,7 +64,7 @@ class ace_arsenal_display {
             sizeEx = QUOTE(7 * GRID_H);
 
             class controls {
-                
+
                 class Title: RscText {
                     idc = 9990001;
                     sizeEx = QUOTE(7 * GRID_H);

--- a/addons/gearinfo/XtdGearModels.hpp
+++ b/addons/gearinfo/XtdGearModels.hpp
@@ -13,7 +13,7 @@ class XtdGearModels
 			label = CSTRING(White);
 			image = QPATHTOF(data\camo\wht.paa);
 		};
-		
+
 	    class BLK
 		{
 			label = CSTRING(Black);
@@ -358,17 +358,17 @@ class XtdGearModels
 	/**
 	 * Conventional options names that can be used by mods, to avoid dependency to this pbo.
 	 */
-	class Conventional 
+	class Conventional
 	{
 		class camo: CamoBase {};
 		class pantscamo: CamoBase {
 			label = CSTRING(PantsCamo);
 		};
 		class sleeves : SleevesBase {};
-		class faction : Faction {};
+		class Faction : Faction {};
 	};
 
-	class CfgWeapons 
+	class CfgWeapons
 	{
 		class U_C_CBRN_Suit_01
 		{

--- a/addons/gearinfo/config.cpp
+++ b/addons/gearinfo/config.cpp
@@ -34,7 +34,7 @@ class Cfg3DEN
 						control="Edit";
 						displayName="Texture options (ACE Arsenal Extended)";
 						tooltip="";
-						expression=QUOTE([ARR_3(_this, _value, false)] call FUNC(setTextureOptions););
+						expression=QUOTE([ARR_3(_this,_value,false)] call FUNC(setTextureOptions););
 						defaultValue="''";
 						condition="objectBrain";
 						wikiType="[[String]]";

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -3,7 +3,7 @@
 
 #include "script_version.hpp"
 
-#define VERSION MAJOR.MINOR.PATCH.BUILD
+#define VERSION MAJOR.MINOR
 #define VERSION_AR MAJOR,MINOR,PATCH,BUILD
 
 #define REQUIRED_VERSION 1.88

--- a/tools/setup.bat
+++ b/tools/setup.bat
@@ -1,0 +1,16 @@
+;@Findstr -bv ;@F "%~f0" | powershell -Command - & pause & goto:eof
+
+Write-Output "=> Downloading ..."
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$url = "https://github.com/BrettMayson/HEMTT/releases/latest/download/windows-x64.zip"
+(New-Object Net.WebClient).DownloadFile($url, "hemtt.zip"); Write-Output "$url => hemtt.zip"
+
+Write-Output "`n=> Extracting ..."
+Expand-Archive -Path "hemtt.zip" -DestinationPath "..\." -Force; Write-Output "hemtt.zip"
+Remove-Item "hemtt.zip"
+
+Write-Output "`n=> Verifying ..."
+Start-Process -FilePath ..\hemtt.exe -ArgumentList --version -NoNewWindow -Wait
+
+Write-Output "`nTools successfully installed to project!"


### PR DESCRIPTION
Updates AceArsenalExtended to most recent HEMTT version. Includes updated gitignore, syntax fixes per hemtt warnings, and included setup.bat to install a hemtt executable for those that don't have it.